### PR TITLE
README: fix some syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,11 @@ You can also run the service in a docker container using the Dockerfile in this 
 1. Be sure you have done the secret_config step from the Initial Setup section.
 2. Build the container.
 
-    ```docker build . -t <some_tag>```
+        docker build . -t <some_tag>
+
 3. Run the container.
 
-   ```docker run -it -p 3000:3000 -v <path_to_secret_config>/.secret_config.js:/xrp-api/.secret_config.js <some_tag>```
+       docker run -it -p 3000:3000 -v <path_to_secret_config>/.secret_config.js:/xrp-api/.secret_config.js <some_tag>
 
 4. You should now be able to run the steps in the tutorial.
 
@@ -130,7 +131,7 @@ You can also run the service in a docker container using the Dockerfile in this 
 * Example: `NODE_DEBUG=prp/pmt node dev`
 * Available categories:
   * `prp/pmt`: GET **/v3/preparations/payments** ([./src/api-v3/paths/preparations/payments.ts](./src/api-v3/paths/preparations/payments.ts))
-* During development, add logging by using [the built-in log levels](https://github.com/xpring-eng/validation-count-reporter/wiki/log4js-node-Log-Levels)
+* During development, add logging by using [the built-in log levels](http://stritti.github.io/log4js/docu/users-guide.html#loglevel)
 
 #### Notes
 


### PR DESCRIPTION
Fix some doc bugs in the README:

- code fences in bulleted lists don't work well in the Markdown parser XRPL.org uses, so switched those to be indented code blocks.

    Screenshot showing what's wrong with [the current version](https://xrpl.org/xrp-api.html#docker-container).

    ![2020-05-21_140127_437287404](https://user-images.githubusercontent.com/7515597/82606263-a4fbe900-9b6b-11ea-943e-2461a05ba40a.png)

- https://github.com/xpring-eng/validation-count-reporter is a private repo, so I replaced the log levels link with a reference from the official log4js site.