### PR TITLE
Add maxLedgerVersionOffset

### DIFF
--- a/api-doc.yml
+++ b/api-doc.yml
@@ -185,6 +185,12 @@ paths:
           required: false
           schema:
             type: string
+        - in: query
+          name: maxLedgerVersionOffset
+          description: Offset from the current validated ledger version to the highest ledger version that the transaction can be included in. For example, for a transaction that will be valid for approximately 25-30 minutes, use a value of `500`.
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: A Prepared Payment Transaction, with min_ledger and max_ledger fields.

--- a/api-doc.yml
+++ b/api-doc.yml
@@ -187,7 +187,7 @@ paths:
             type: string
         - in: query
           name: maxLedgerVersionOffset
-          description: Offset from the current validated ledger version to the highest ledger version that the transaction can be included in. For example, for a transaction that will be valid for approximately 25-30 minutes, use a value of `500`.
+          description: Offset from the current validated ledger version to the highest ledger version that the transaction can be included in. This effectively serves as the transaction's expiration time, after which it is invalid. Transactions are typically validated within 2-3 ledgers, but transactions that are signed manually and/or offline may need longer validity times. A ledger is created every 3-4 seconds. For example, a value of `500` would prepare a transaction that will be valid for approximately 25-30 minutes.
           required: false
           schema:
             type: string

--- a/src/api-v3/paths/accounts/{address}/info.spec.ts
+++ b/src/api-v3/paths/accounts/{address}/info.spec.ts
@@ -10,10 +10,6 @@ import accountInfoLedgerIndexFooResponseFixture from '../../../../fixtures/accou
 const path = '/v3/accounts/{address}/info';
 
 describe(path, () => {
-  afterEach(() => {
-    sinon.restore();
-  });
-
   it('GET - returns account info', (done) => {
     sinon.stub(rippleApi, 'isConnected').returns(true);
     sinon.stub(rippleApi, 'request').resolves(getAccountInfoFixture);
@@ -77,9 +73,5 @@ describe(path, () => {
         expect(capture(mockedDebuglog.log).byCallIndex(0)).to.deep.equal(["\u001b[31m%s\u001b[0m","/v3/accounts/{address}/info validation:",{"message":"The response was not valid.","errors":[{"path":"account_data","errorCode":"additionalProperties.openapi.responseValidation","message":"account_data should NOT have additional properties"}]}]);
       })
       .end(done);
-  });
-
-  afterEach(() => {
-    sinon.restore();
   });
 });

--- a/src/api-v3/paths/accounts/{address}/settings.spec.ts
+++ b/src/api-v3/paths/accounts/{address}/settings.spec.ts
@@ -54,8 +54,4 @@ describe.skip(path, () => {
   //     })
   //     .end(done);
   // });
-
-  afterEach(() => {
-    sinon.restore();
-  });
 });

--- a/src/api-v3/paths/payments.spec.ts
+++ b/src/api-v3/paths/payments.spec.ts
@@ -46,8 +46,4 @@ describe(path, () => {
       .expect(400, {"errors":[{"name":"actNotFound","message":"Account not found.","code":19,"request":{"account":"rLRnD5g6eb3TWrvfHoZ8y2mRznuu7GJzeN","command":"account_info","id":3}}],"message":"The account (rLRnD5g6eb3TWrvfHoZ8y2mRznuu7GJzeN) could not be found as of ledger 1377457 (command: account_info)"})
       .end(done);
   });
-
-  afterEach(() => {
-    sinon.restore();
-  });
 });

--- a/src/api-v3/paths/preparations/payments.spec.ts
+++ b/src/api-v3/paths/preparations/payments.spec.ts
@@ -1,0 +1,126 @@
+// Unit tests for:
+//     GET /v3/preparations/payments
+
+import sinon from 'sinon';
+import request from 'supertest';
+import { mockApp, rippleApi } from "../../../fixtures/mocks";
+import { expect } from 'chai';
+
+const path = '/v3/preparations/payments';
+
+describe(path, () => {
+  it('prepares a payment - normal happy path', (done) => {
+    sinon.stub(rippleApi.connection, 'getReserveBase').resolves(20000000);
+    sinon.stub(rippleApi, 'request').withArgs('account_info', sinon.match.any).resolves({
+      account_data: {
+        Balance: "20000000",
+        Flags: 0
+      }
+    });
+    sinon.stub(rippleApi, 'getLedgerVersion').resolves(7000000);
+    sinon.stub(rippleApi, 'prepareTransaction').withArgs(sinon.match.any, {}).resolves({
+      txJSON: JSON.stringify({
+        "TransactionType": "Payment",
+        "Account": "rNQao3Z1irwRjKWSs8heL4a8WKLPKfLrXs",
+        "Destination": "rpgHWJdXkSvvzikdJCpuMzU7zWnuqsJRCZ",
+        "Amount": "123000000",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 7000003,
+        "Fee": "12",
+        "Sequence": 7
+      }),
+      instructions: {
+        fee: "0.000012",
+        sequence: 7
+      }
+    });
+
+    // GIVEN a source, destination, and amount to send
+    const query = {
+      source: 'XVDDpvwxP3yZaZGU1Gik6HxJ4kkAEy6roNBwRFT3eRecYmH',
+      destination: 'X7ZrF85JfL7AwEg7MTwHuWNJjCrPrhHL3bPGHU9UASVz4eX',
+      value: '123',
+      currency: 'XRP'
+    };
+
+    // WHEN preparing a payment
+    request(mockApp)
+      .get(path)
+      .query(query)
+      .expect(200)
+      // THEN return a payment
+      .expect({
+        "TransactionType": "Payment",
+        "Account": "rNQao3Z1irwRjKWSs8heL4a8WKLPKfLrXs",
+        "Destination": "rpgHWJdXkSvvzikdJCpuMzU7zWnuqsJRCZ",
+        "Amount": "123000000",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 7000003,
+        "Fee": "12",
+        "Sequence": 7,
+        "min_ledger": 7000000,
+        "max_ledger": 7000003
+      })
+      .end(done);
+  });
+
+  it('prepares a payment with a custom maxLedgerVersionOffset', (done) => {
+    sinon.stub(rippleApi.connection, 'getReserveBase').resolves(20000000);
+    sinon.stub(rippleApi, 'request').withArgs('account_info', sinon.match.any).resolves({
+      account_data: {
+        Balance: "20000000",
+        Flags: 0
+      }
+    });
+    sinon.stub(rippleApi, 'getLedgerVersion').resolves(7000000);
+    sinon.stub(rippleApi, 'prepareTransaction').withArgs(sinon.match.any, {maxLedgerVersionOffset: 500}).resolves({
+      txJSON: JSON.stringify({
+        "TransactionType": "Payment",
+        "Account": "rNQao3Z1irwRjKWSs8heL4a8WKLPKfLrXs",
+        "Destination": "rpgHWJdXkSvvzikdJCpuMzU7zWnuqsJRCZ",
+        "Amount": "123000000",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 7000500,
+        "Fee": "12",
+        "Sequence": 7
+      }),
+      instructions: {
+        fee: "0.000012",
+        sequence: 7
+      }
+    });
+
+    // GIVEN a maxLedgerVersionOffset
+    const maxLedgerVersionOffset = 500;
+
+    // WHEN preparing a payment
+    request(mockApp)
+      .get(path)
+      .query({
+        source: 'XVDDpvwxP3yZaZGU1Gik6HxJ4kkAEy6roNBwRFT3eRecYmH',
+        destination: 'X7ZrF85JfL7AwEg7MTwHuWNJjCrPrhHL3bPGHU9UASVz4eX',
+        value: '123',
+        currency: 'XRP',
+        maxLedgerVersionOffset
+      })
+      .expect(200)
+      .expect(res => {
+        // THEN return a payment with LastLedgerSequence 500 greater than min_ledger
+        expect(res.body.min_ledger + maxLedgerVersionOffset).to.equal(res.body.LastLedgerSequence);
+        expect(res.body.min_ledger + maxLedgerVersionOffset).to.equal(res.body.max_ledger);
+      })
+      .expect({
+        "TransactionType": "Payment",
+        "Account": "rNQao3Z1irwRjKWSs8heL4a8WKLPKfLrXs",
+        "Destination": "rpgHWJdXkSvvzikdJCpuMzU7zWnuqsJRCZ",
+        "Amount": "123000000",
+        "Flags": 2147483648,
+        "LastLedgerSequence": 7000500,
+        "Fee": "12",
+        "Sequence": 7,
+        "min_ledger": 7000000,
+        "max_ledger": 7000500
+      })
+      .end(done);
+  });
+});

--- a/src/api-v3/paths/preparations/payments.spec.ts
+++ b/src/api-v3/paths/preparations/payments.spec.ts
@@ -65,6 +65,7 @@ describe(path, () => {
   });
 
   it('prepares a payment with a custom maxLedgerVersionOffset', (done) => {
+    // GIVEN mocked networking and a max ledger version offset
     sinon.stub(rippleApi.connection, 'getReserveBase').resolves(20000000);
     sinon.stub(rippleApi, 'request').withArgs('account_info', sinon.match.any).resolves({
       account_data: {
@@ -89,8 +90,6 @@ describe(path, () => {
         sequence: 7
       }
     });
-
-    // GIVEN a maxLedgerVersionOffset
     const maxLedgerVersionOffset = 500;
 
     // WHEN preparing a payment

--- a/src/api-v3/paths/preparations/payments.ts
+++ b/src/api-v3/paths/preparations/payments.ts
@@ -206,7 +206,7 @@ export default function(api: RippleAPI, log: Function): Operations {
     }
 
     const removeUndefined = (obj: {
-      [key: string]: string | object | undefined;
+      [key: string]: string | number | object | undefined;
     }): object => {
       Object.keys(obj).forEach(key => obj[key] === undefined && delete obj[key]);
       return obj;
@@ -217,10 +217,13 @@ export default function(api: RippleAPI, log: Function): Operations {
       Destination: options.destination,
       Amount
     }) as TransactionJSON;
+    const instructions = removeUndefined({
+      maxLedgerVersionOffset: options.maxLedgerVersionOffset ? parseInt(options.maxLedgerVersionOffset) : undefined
+    });
 
     try {
       logger.trace('Preparing', transaction);
-      const prepared = await api.prepareTransaction(transaction);
+      const prepared = await api.prepareTransaction(transaction, instructions);
       const response = JSON.parse(prepared.txJSON);
       res.status(200).json(Object.assign(response, {
         min_ledger: await api.getLedgerVersion(),

--- a/src/api-v3/paths/servers/info.spec.ts
+++ b/src/api-v3/paths/servers/info.spec.ts
@@ -52,8 +52,4 @@ describe(path, () => {
       })
       .end(done);
   });
-
-  afterEach(() => {
-    sinon.restore();
-  });
 });

--- a/src/api-v3/paths/transactions/{transaction_id}.spec.ts
+++ b/src/api-v3/paths/transactions/{transaction_id}.spec.ts
@@ -14,9 +14,6 @@ describe(path, () => {
     sinon.stub(rippleApi, 'isConnected').returns(true);
     sinon.stub(rippleApi, 'getLedgerVersion').returns(Promise.resolve(7145670));
   });
-  afterEach(() => {
-    sinon.restore();
-  });
 
   it('finds a tx', (done) => {
     sinon.stub(rippleApi, 'request').resolves(txFixture);

--- a/src/api-v3/services/ripple-api.spec.ts
+++ b/src/api-v3/services/ripple-api.spec.ts
@@ -90,7 +90,4 @@
 //       .end(done);
 //   });
 
-//   afterEach(() => {
-//     sinon.restore();
-//   });
 // });

--- a/src/fixtures/mocks.ts
+++ b/src/fixtures/mocks.ts
@@ -2,6 +2,7 @@ import { mock, instance, when, resetCalls } from 'ts-mockito';
 import { Server } from '../server';
 import RippleApiService from '../api-v3/services/ripple-api';
 import { RippleAPI } from 'ripple-lib';
+import sinon from 'sinon';
 
 class Debuglog {
   public setKey(_key: string): void {}
@@ -32,6 +33,11 @@ const app = server.expressApp();
 
 afterEach(() => {
   resetCalls(mockedDebuglog);
+});
+
+afterEach(() => {
+  // Reset all stubs after each test
+  sinon.restore();
 });
 
 export {


### PR DESCRIPTION
## High Level Overview of Change

By default, ripple-lib currently prepares transactions with a maxLedgerVersionOffset of 3, so transactions are usually valid for less than 10 seconds. This can be ok for automated systems, but it is too short for manual use cases and slower systems. `maxLedgerVersionOffset` allows for customizing this value.

### Context of Change

If you submit a transaction that has expired due to `LastLedgerSequence`, you'll get the `tefMAX_LEDGER` error. More specifically, you will have `response.engine_result === 'tefMAX_LEDGER'`.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

A unit test is included in this PR.
