### PR TITLE
update README to assume docker container is run from the project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can also run the service in a docker container using the Dockerfile in this 
 
 3. Run the container.
 
-       docker run -it -p 3000:3000 -v <path_to_secret_config>/.secret_config.js:/xrp-api/.secret_config.js <some_tag>
+       docker run -it -p 3000:3000 -v $PWD/.secret_config.js:/xrp-api/.secret_config.js <some_tag>
 
 4. You should now be able to run the steps in the tutorial.
 


### PR DESCRIPTION
## High Level Overview of Change

This is a simple update to the README which saves a step for most users testing or running the docker image from the project root. It assumes the the image will be run from the project root.

### Type of Change

- [x] Documentation Updates

## Test Plan

N/A
