### PR TITLE
Update API ref link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An API server that provides a REST-like interface to the XRP Ledger.
 
 
-## [➡️ XRP API Reference Documentation](https://xrpl.org/xrp-api.html)
+## [➡️ XRP API Reference Documentation](https://xpring-eng.github.io/xrp-api/)
 
 See the full reference documentation on the XRP Ledger Dev Portal.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,3 +26,27 @@ Example:
 You can specify multiple categories separated by `,`:
 
     NODE_DEBUG=paths,ripple-api yarn dev
+
+## Updating Docs
+
+The [API Reference](https://xpring-eng.github.io/xrp-api/) is based on the [`api-doc.yml` file](../api-doc.yml) and hosted using GitHub Pages. To update it, you need to have [Dactyl](https://github.com/ripple/dactyl/) installed (`pip install dactyl`). Then complete the following steps:
+
+1. Merge changes from the master branch into the `gh-pages` branch.
+
+        # From the repo base directory:
+        git checkout master
+        git pull
+        git switch gh-pages
+        git merge master
+
+2. Build the API docs using the OpenAPI spec:
+
+        dactyl_build --openapi api-doc.yml -o .
+
+3. Commit the updated HTML files:
+
+        git add ./*.html
+        git commit -m "[gh-pages] Update docs"
+        git push
+
+4. Wait a couple minutes for changes to propagate.


### PR DESCRIPTION
## High Level Overview of Change

Moves the API reference docs link to GitHub Pages in preparation for removing them from xrpl.org.

### Context of Change

Since this project is not being actively developed, we decided to take it down from xrpl.org to reduce confusion. Moving the reference docs to GitHub Pages allows this repo to stand more or less by itself regardless of what happens with it in the future.

### Type of Change

- [x] Documentation Updates

